### PR TITLE
feat: Add maskInput option to toggle input visibility as password

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Il supporte plusieurs options de configuration pour gérer les entiers, les nomb
 | `onValueChange`     | `function`   | Fonction déclenchée lorsque la valeur change.                                                    | `null`            |
 | `isDisabled`       | `boolean`        | Permet de désactiver les inputs. Si activé, les champs ne seront pas modifiables par l'utilisateur. Dans le cas d'un CodeInput de type "text" cette option n'est pas utilisable.                                             | `true`            |
 | `allowArrowKeys`       | `boolean`        | Active ou désactive la fonctionnalité de navigation via les touches `ArrowLeft`,`ArrowRight`,`ArrowUp`,`ArrowDown`.                                             | `false`            |
+| `maskInput`  | `bool`  | Masque les entrées avec des étoiles (*) comme un mot de passe | `false`           |
 
 ## Exemples
 

--- a/exemples/index.html
+++ b/exemples/index.html
@@ -261,6 +261,14 @@
                    </div>
                </div>
            </div>
+
+           <h4 class="mt-3">Masquer l'affichage des entrées comme un mot de passe :</h4>
+
+           <div class="form-check form-switch mb-3">
+               <input class="form-check-input" type="checkbox" id="toggleMaskInput">
+               <label class="form-check-label" for="toggleMaskInput">Masquer/Demasquer les entrées</label>
+           </div>
+           <br>
            <h4 class="mt-3">Valeur de l'input modifié (Letter) :</h4>
            <p id="changeValueDisplayLetter">Aucun changement</p>
            <h4>Valeur complète (Letter) :</h4>
@@ -444,8 +452,6 @@
                 label.text(this.checked ? 'Désactiver les champs Float' : 'Activer les champs Float');
             });
 
-            toggleEnableFloat
-
             // Gestionnaire de clic pour afficher la valeur complète
             $('#getCompleteValueButtonFloat').on('click', function() {
                 const completeCode = codeInputFloat.getCompleteValue();
@@ -601,6 +607,7 @@
                 values: [0x00, 0xcd, 14, '0', 'µ'],
                 minValues: [0x00, 0x00, 0x00, 0x00, 0x00],
                 maxValues: [0xff, 0xff, 0xff, 0xff, 0xff],
+                maskInput: false,
                 onValueChange: function($input, newValue) {
                     // Affichage de la valeur de l'input modifié
                     $('#changeValueDisplayLetter').text(`Input ${$input.attr('id')} a changé de valeur : ${newValue}`);
@@ -609,6 +616,11 @@
                     const completeCode = codeInputLetter.getCompleteValue();
                     $('#completeValueDisplayLetter').text(`Valeur actuelle : ${completeCode}`);
                 }
+            });
+
+            $('#toggleMaskInput').on('change', function () {
+                const isPassword = this.checked; // Vérifie si la case est cochée
+                codeInputLetter.changeMaskInputs(isPassword);
             });
             
             // Gestionnaire de clic pour afficher la valeur complète

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-input-builder",
-  "version": "8",
+  "version": "0.0.18",
   "description": "Plugin jQuery pour créer des champs d'input configurables",
   "main": "src/codeinputbuilder.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-input-builder",
-  "version": "0.0.17",
+  "version": "8",
   "description": "Plugin jQuery pour créer des champs d'input configurables",
   "main": "src/codeinputbuilder.js",
   "scripts": {

--- a/src/codeinputbuilder.js
+++ b/src/codeinputbuilder.js
@@ -1,6 +1,6 @@
 /*
 Plugin: Code Input Builder
-Version: 0.0.17
+Version: 0.0.18
 Author: Daumand David
 Website: https://www.timecaps.io
 Contact: daumanddavid@gmail.com
@@ -81,6 +81,9 @@ Options disponibles:
     - `allowArrowKeys`: (boolean) Permet d'active la fonctionnalité de navigation via les touches `ArrowLeft`,`ArrowRight`,`ArrowUp`,`ArrowDown`
       * Par défaut : false.
 
+    - `maskInput`: (boolean) Permet de masquer ou afficher les inputs au format password
+      * Par défaut : false.
+
 Usage basique :
     $('#element').codeInputBuilder({
         type: 'float',
@@ -130,6 +133,7 @@ if (typeof jQuery === 'undefined') {
       gap: '10px',
       isDisabled: false,
       allowArrowKeys: false,
+      maskInput: false,
     };
 
     const settings = $.extend({}, defaultOptions, options);
@@ -148,6 +152,12 @@ if (typeof jQuery === 'undefined') {
         throw new Error(
           "Option 'type' invalide. Valeurs autorisées : 'integer', 'float', 'text','binary', 'hexadecimal', 'letter'."
         );
+      }
+    }
+
+    function validateMaskInput(maskInput) {
+      if (typeof maskInput !== 'boolean') {
+        throw new Error("Option 'maskInput' doit être un booléen.");
       }
     }
 
@@ -326,6 +336,7 @@ if (typeof jQuery === 'undefined') {
       validateScrollSensitivity(settings.scrollSensitivity);
       validateRequireKeyForScroll(settings.requireKeyForScroll);
       validateDefaultSign(settings.defaultSign);
+      validateMaskInput(settings.maskInput);
     }
 
     validateOptions();
@@ -1711,7 +1722,11 @@ if (typeof jQuery === 'undefined') {
     /* Gestionnaire de modification de la mollette de la souris */
 
     function adjustOnScroll(inputElement, event, prefix, type) {
-      if (!settings.allowScroll) return;
+
+      if (settings.maskInput === true)
+        return;
+      if (!settings.allowScroll) 
+        return;
       const originalEvent = event.originalEvent || event;
       originalEvent.preventDefault();
 
@@ -1896,6 +1911,10 @@ if (typeof jQuery === 'undefined') {
     }
 
     function hoverMouseEnter(inputElement, prefix, type) {
+
+      if (settings.maskInput === true)
+        return;
+      
       let id = convertIntegerBase10(
         $(inputElement)
           .attr('id')
@@ -2174,7 +2193,7 @@ if (typeof jQuery === 'undefined') {
       $('body').append($liveRegion);
 
       const $input = $('<input>', {
-        type: 'text',
+        type: settings.maskInput === true ? 'password' : 'text',
         class: `form-control form-control-lg text-center cla-h2-like ${prefix}-input`,
         maxLength: maxLength,
         id: `${prefix}_${uniqueTypeShort}_input_${id}`,
@@ -2218,14 +2237,14 @@ if (typeof jQuery === 'undefined') {
           adjustOnScroll($element, event, prefix, uniqueTypeShort);
         })
         .hover(
-          function () {
-            if (settings.type != 'text' && settings.isDisabled) return;
-            hoverMouseEnter(this, prefix, uniqueTypeShort);
-          },
-          function () {
-            if (settings.type != 'text' && settings.isDisabled) return;
-            hoverMouseLeave(this, prefix, uniqueTypeShort);
-          }
+            function () {
+              if (settings.type != 'text' && settings.isDisabled) return;
+              hoverMouseEnter(this, prefix, uniqueTypeShort);
+            },
+            function () {
+              if (settings.type != 'text' && settings.isDisabled) return;
+              hoverMouseLeave(this, prefix, uniqueTypeShort);
+            }
         )
         .on('paste', (event) => {
           const $element = $(event.currentTarget);
@@ -2433,6 +2452,13 @@ if (typeof jQuery === 'undefined') {
           'settings.type non disponible avec la fonction setDigitAt.'
         );
       }
+    };
+
+    this.changeMaskInputs = function (isPassword) {
+      settings.maskInput = isPassword; // Met à jour l'option dans les paramètres
+      this.find('input').each(function () {
+          $(this).attr('type', isPassword ? 'password' : 'text'); // Change le type d'input
+      });
     };
 
     this.toggleInputs = function (disabled) {
@@ -2646,7 +2672,7 @@ if (typeof jQuery === 'undefined') {
     });
   };
 
-  $.fn.codeInputBuilder.version = '0.0.17';
+  $.fn.codeInputBuilder.version = '0.0.18';
   $.fn.codeInputBuilder.title = 'CodeInputBuilder';
   $.fn.codeInputBuilder.description =
     "Plugin jQuery permettant de générer des champs d'input configurables pour la saisie de valeurs numériques (entiers, flottants), de textes, ou de valeurs dans des systèmes spécifiques (binaire, hexadécimal). Il offre des options avancées de personnalisation incluant la gestion des signes, des positions décimales, des limites de valeurs, et des callbacks pour la gestion des changements de valeur.";

--- a/src/codeinputbuilder.js
+++ b/src/codeinputbuilder.js
@@ -1722,11 +1722,8 @@ if (typeof jQuery === 'undefined') {
     /* Gestionnaire de modification de la mollette de la souris */
 
     function adjustOnScroll(inputElement, event, prefix, type) {
-
-      if (settings.maskInput === true)
-        return;
-      if (!settings.allowScroll) 
-        return;
+      if (settings.maskInput === true) return;
+      if (!settings.allowScroll) return;
       const originalEvent = event.originalEvent || event;
       originalEvent.preventDefault();
 
@@ -1911,10 +1908,8 @@ if (typeof jQuery === 'undefined') {
     }
 
     function hoverMouseEnter(inputElement, prefix, type) {
+      if (settings.maskInput === true) return;
 
-      if (settings.maskInput === true)
-        return;
-      
       let id = convertIntegerBase10(
         $(inputElement)
           .attr('id')
@@ -2237,14 +2232,14 @@ if (typeof jQuery === 'undefined') {
           adjustOnScroll($element, event, prefix, uniqueTypeShort);
         })
         .hover(
-            function () {
-              if (settings.type != 'text' && settings.isDisabled) return;
-              hoverMouseEnter(this, prefix, uniqueTypeShort);
-            },
-            function () {
-              if (settings.type != 'text' && settings.isDisabled) return;
-              hoverMouseLeave(this, prefix, uniqueTypeShort);
-            }
+          function () {
+            if (settings.type != 'text' && settings.isDisabled) return;
+            hoverMouseEnter(this, prefix, uniqueTypeShort);
+          },
+          function () {
+            if (settings.type != 'text' && settings.isDisabled) return;
+            hoverMouseLeave(this, prefix, uniqueTypeShort);
+          }
         )
         .on('paste', (event) => {
           const $element = $(event.currentTarget);
@@ -2457,7 +2452,7 @@ if (typeof jQuery === 'undefined') {
     this.changeMaskInputs = function (isPassword) {
       settings.maskInput = isPassword; // Met à jour l'option dans les paramètres
       this.find('input').each(function () {
-          $(this).attr('type', isPassword ? 'password' : 'text'); // Change le type d'input
+        $(this).attr('type', isPassword ? 'password' : 'text'); // Change le type d'input
       });
     };
 


### PR DESCRIPTION
- Introduced the `maskInput` option to allow masking inputs (type="password").
- Updated event handling to dynamically switch between "text" and "password".
- Updated documentation and examples to reflect this new feature.
- Bumped version from 0.0.17 to 0.0.18.